### PR TITLE
Update maven setup docs with Github package auth instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 - Placeholder for upcoming features and enhancements.
 
 ### Fixed
-
-- Added missing step to change directory to [local deployment](/DeveloperDocumentation/Deployment//deployment-local.md) documentation when cloning and setting up repositories.
-- Updated [local deployment](/DeveloperDocumentation/Deployment/deployment-local.md) documentation clarity (including the correct steps for configuring `fuseki-yaml-config`).
+- Added missing step to change directory to [local deployment](DeveloperDocumentation/Deployment/deployment-local.md) documentation when cloning and setting up repositories.
+- Updated [local deployment](DeveloperDocumentation/Deployment/deployment-local.md) documentation clarity, including:
+  - Correct steps for configuring `fuseki-yaml-config`
+  - Instructions on setting up authentication for fetching GitHub packages
 
 ### Changed
 - Updated MAINTAINERS.md with updated supplier information.

--- a/DeveloperDocumentation/Deployment/deployment-local.md
+++ b/DeveloperDocumentation/Deployment/deployment-local.md
@@ -73,7 +73,7 @@ and some details about that user should be shown.
     ```
    If the directory does not exist, create it
     
-    ```shell
+   ```shell
    mkdir .m2
    ```
 


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

During installation multiple devs got stuck on setting up a PAT token and adding it to the `settings.xml` file. In order to make things clearer, we are going to update the docs with concise instructions.

## Description

The documentation has been updated with clearer steps on updating the `settings.xml` file and adding their credentials, including how to locate their `.m2` directory, as per ticket description.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
