### PR TITLE
Add missing change directory instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 - Placeholder for upcoming features and enhancements.
 
 ### Fixed
-- Placeholder for bug fixes and security updates.
+- Added missing step to change directory to [local deployment](/DeveloperDocumentation/Deployment//deployment-local.md) documentation when cloning and setting up repositories.
 
 ### Changed
 - Updated MAINTAINERS.md with updated supplier information.

--- a/DeveloperDocumentation/Deployment/deployment-local.md
+++ b/DeveloperDocumentation/Deployment/deployment-local.md
@@ -73,6 +73,7 @@ cd ..
 git clone https://github.com/National-Digital-Twin/jwt-servlet-auth
 cd jwt-servlet-auth
 mvn clean install
+cd ..
 git clone https://github.com/National-Digital-Twin/secure-agents-lib.git
 cd secure-agents-lib
 (Ensure Docker is running as the tests use it)


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

During setting up of an IA node locally, in the setup instructions section **`Fetch source code and build packages`**, before cloning `secure-agents-lib`, there is a missing `cd ..` step. The omission of this steps would mean the person following the docs would end up checking out `secure-agents-lib` inside the `jwt-servlet-auth` directory.

## Description

The documentation has been updated with the missing `cd ..` step to avoid the follower of this documentation to checkout `secure-agents-lib` inside `jwt-servlet-auth`.

### To Test
- Checkout branch
- Locate this guide **`deployment-local.md`**, the full path to the file is **`DeveloperDocumentation/Deployment/deployment-local.md`**.
- Within the previously mentioned doc, locate the **`Fetch source code and build packages`** section.
- After the following steps:
```
git clone https://github.com/National-Digital-Twin/jwt-servlet-auth
cd jwt-servlet-auth
mvn clean install
```
- The next steps after **`mvn clean install`** should be `cd ..`.
  - Confirm this step exists.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
