### PR TITLE
Update documentation to comment bash code correctly

### DIFF
--- a/DeveloperDocumentation/Deployment/deployment-local.md
+++ b/DeveloperDocumentation/Deployment/deployment-local.md
@@ -44,10 +44,10 @@ docker compose up mongo -d
 
 Start up access support mechanism
 ```
-source ./token_env.sh [Sets some environment variables for local running with tokens]
-export SCIM_ENABLED=true [So that cognito-local is used]
+source ./token_env.sh # Sets some environment variables for local running with tokens
+export SCIM_ENABLED=true # So that cognito-local is used
 yarn install
-OPENID_PROVIDER_URL=development DEPLOYED_DOMAIN="http://localhost:3000" GROUPS_KEY="cognito:groups" yarn dev [Run server providing API]
+OPENID_PROVIDER_URL=development DEPLOYED_DOMAIN="http://localhost:3000" GROUPS_KEY="cognito:groups" yarn dev # Run server providing API
 ```
 (leave that running)
 


### PR DESCRIPTION
Bash code in local deployment documentation will cause an error if copied and run verbatim. Minor issue but for user simplicity and to avoid confusion the comments now use the correct '#' for comments